### PR TITLE
nowplaying 페이지의 GoodBadButton 삭제

### DIFF
--- a/src/components/Buttons/GoodBadButton.tsx
+++ b/src/components/Buttons/GoodBadButton.tsx
@@ -11,6 +11,8 @@ import { useEffect, useState } from "react";
 
 import { auth, db } from "../../../firebase";
 import { IUserMovies, IGenre } from "../../interfaces";
+import { useRecoilState } from "recoil";
+import { ratingState } from "../../atom";
 
 interface IGoodBadButtonProps {
   type: "good" | "bad";
@@ -28,7 +30,7 @@ export default function GoodBadButton({
 }: IGoodBadButtonProps) {
   const user = auth.currentUser;
   const toast = useToast();
-  const [rating, setRating] = useState("");
+  const [rating, setRating] = useRecoilState(ratingState);
 
   useEffect(() => {
     onAuthStateChanged(auth, async (user) => {

--- a/src/components/Buttons/GoodBadButton.tsx
+++ b/src/components/Buttons/GoodBadButton.tsx
@@ -26,10 +26,10 @@ export default function GoodBadButton({
   movieId,
   genres,
 }: IGoodBadButtonProps) {
-  const toast = useToast();
   const user = auth.currentUser;
-
+  const toast = useToast();
   const [rating, setRating] = useState("");
+
   useEffect(() => {
     onAuthStateChanged(auth, async (user) => {
       // 로그인 사용자이면 좋아요/별로예요 평가 설정하기
@@ -92,6 +92,7 @@ export default function GoodBadButton({
 
     // 좋아요 버튼을 누르면
     if (type === "good") {
+      setRating((current) => (current === "good" ? "" : "good"));
       if (rating === "good") {
         updatedGood = updatedGood?.filter((id: number) => id !== movieId);
       }
@@ -104,6 +105,7 @@ export default function GoodBadButton({
       }
     } else {
       // 별로예요 버튼을 누르면
+      setRating((current) => (current === "bad" ? "" : "bad"));
       if (rating === "bad") {
         updatedBad = updatedBad?.filter((id: number) => id !== movieId);
       }
@@ -173,13 +175,6 @@ export default function GoodBadButton({
       const { updatedGood, updatedBad } = await getUpdatedMovies();
       const updatedGenresObj = await getUpdatedGenres();
       saveMoviesToDB(updatedGood, updatedBad, updatedGenresObj);
-
-      // rating state 바꾸기
-      if (type === "good") {
-        setRating((current) => (current === "good" ? "" : "good"));
-      } else {
-        setRating((current) => (current === "bad" ? "" : "bad"));
-      }
     }
   };
 
@@ -207,12 +202,12 @@ export default function GoodBadButton({
       >
         {type === "good" ? (
           rating === "good" ? (
-            <RiThumbUpFill size="1.4rem" />
+            <RiThumbUpFill size="1.4rem" color="brightBlue" />
           ) : (
             <RiThumbUpLine size="1.4rem" />
           )
         ) : rating === "bad" ? (
-          <RiThumbDownFill size="1.4rem" />
+          <RiThumbDownFill size="1.4rem" color="brightBlue" />
         ) : (
           <RiThumbDownLine size="1.4rem" />
         )}

--- a/src/components/NowPlayingCard.tsx
+++ b/src/components/NowPlayingCard.tsx
@@ -46,21 +46,6 @@ function NowPlayingCard({ info, page, key }: CardProps) {
             src={`https:www.themoviedb.org/t/p/w1280${info.poster_path}`}
             borderRadius={5}
           />
-          <Flex mt={5}>
-            <GoodBadButton
-              type="good"
-              movieId={info.id}
-              genres={detail.genres}
-            />
-            <Box mr={3} ml={3}>
-              <GoodBadButton
-                type="bad"
-                movieId={info.id}
-                genres={detail.genres}
-              />
-            </Box>
-            <WatchButton movieId={info.id} />
-          </Flex>
         </Flex>
         <Flex direction="column" ml={10}>
           <Text fontSize="1.2rem" mb={1}>
@@ -104,7 +89,7 @@ function NowPlayingCard({ info, page, key }: CardProps) {
           <Flex mt="9rem">
             <ReserveButton />
             <Button
-              ml="1rem"
+              mx="1rem"
               borderColor="pink"
               borderWidth={1}
               bgColor="transparent"
@@ -112,6 +97,7 @@ function NowPlayingCard({ info, page, key }: CardProps) {
             >
               관련 정보
             </Button>
+            <WatchButton movieId={info.id} />
           </Flex>
         </Flex>
       </Flex>


### PR DESCRIPTION
## 기능 설명
'좋아요'와 '별로예요'가 동시에 눌리는 걸 방지하기 위해 nowplaying 페이지에서 버튼을 삭제함.

## 추가 사항
- `Recoil`을 사용하면 '좋아요'와 '별로예요'가 동시에 눌리지 않는 대신, nowplaying 페이지 처럼, **한 화면에 버튼이 여러 개 있으면**, '좋아요' 또는 '별로예요'가 모두 동시에 눌린다.
- `useState`를 사용하면 영화마다 버튼이 개별로 작동하지만, '좋아요'에서 '별로예요'(또는 반대)로 바꿀 때, 바로 '좋아요'가 풀리지 않는다. (새로고침하면 반영된다)
